### PR TITLE
feat(ui): navigate list with Ctrl+P / Ctrl+N

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ sends the theme name via `HERDR_PLUGIN_CONTEXT_JSON`.
 
 | Key | Action |
 |---|---|
-| `↑` / `↓` | Navigate list |
+| `↑` / `↓` or `Ctrl+P` / `Ctrl+N` | Navigate list |
 | `Tab` / `Shift+Tab` | Cycle category tabs |
 | `Enter` | Focus selected item |
 | `Esc` | Clear search / close |

--- a/src/app.rs
+++ b/src/app.rs
@@ -66,33 +66,45 @@ impl AppState {
                 KeyAction::Continue
             }
 
-            // Up/Down arrows: navigate list (wrap around)
-            (KeyCode::Up, _) => {
-                if list_len == 0 {
-                    self.selected_index = 0;
-                } else {
-                    self.selected_index = if self.selected_index == 0 {
-                        list_len - 1
-                    } else {
-                        self.selected_index - 1
-                    };
-                }
+            // Up / Ctrl+P: previous item (wrap around)
+            (KeyCode::Up, _) | (KeyCode::Char('p'), KeyModifiers::CONTROL) => {
+                self.select_prev(list_len);
                 KeyAction::Continue
             }
-            (KeyCode::Down, _) => {
-                if list_len == 0 {
-                    self.selected_index = 0;
-                } else {
-                    self.selected_index = if self.selected_index >= list_len - 1 {
-                        0
-                    } else {
-                        self.selected_index + 1
-                    };
-                }
+
+            // Down / Ctrl+N: next item (wrap around)
+            (KeyCode::Down, _) | (KeyCode::Char('n'), KeyModifiers::CONTROL) => {
+                self.select_next(list_len);
                 KeyAction::Continue
             }
 
             _ => KeyAction::Continue,
+        }
+    }
+
+    /// Move selection to the previous item, wrapping to the end.
+    fn select_prev(&mut self, list_len: usize) {
+        if list_len == 0 {
+            self.selected_index = 0;
+        } else {
+            self.selected_index = if self.selected_index == 0 {
+                list_len - 1
+            } else {
+                self.selected_index - 1
+            };
+        }
+    }
+
+    /// Move selection to the next item, wrapping to the start.
+    fn select_next(&mut self, list_len: usize) {
+        if list_len == 0 {
+            self.selected_index = 0;
+        } else {
+            self.selected_index = if self.selected_index >= list_len - 1 {
+                0
+            } else {
+                self.selected_index + 1
+            };
         }
     }
 }
@@ -227,6 +239,55 @@ mod tests {
         assert_eq!(state.search_query, "x");
         let action = state.handle_key(make_key(KeyCode::Esc, KeyModifiers::NONE), 10);
         assert_eq!(action, KeyAction::Continue);
+        assert!(state.search_query.is_empty());
+    }
+
+    /// Ctrl+N walks down the list and wraps to the top
+    #[test]
+    fn test_ctrl_n_moves_down_and_wraps() {
+        let nodes = mock_nodes();
+        let mut state = AppState::new(nodes);
+
+        let ctrl_n = make_key(KeyCode::Char('n'), KeyModifiers::CONTROL);
+        for expected in [1, 2, 0] {
+            state.handle_key(ctrl_n, 3);
+            assert_eq!(state.selected_index, expected);
+        }
+    }
+
+    /// Ctrl+P walks up the list, wrapping to the bottom from the top
+    #[test]
+    fn test_ctrl_p_moves_up_and_wraps() {
+        let nodes = mock_nodes();
+        let mut state = AppState::new(nodes);
+
+        let ctrl_p = make_key(KeyCode::Char('p'), KeyModifiers::CONTROL);
+        for expected in [2, 1, 0] {
+            state.handle_key(ctrl_p, 3);
+            assert_eq!(state.selected_index, expected);
+        }
+    }
+
+    /// Ctrl+N / Ctrl+P on an empty list stay at 0 (no underflow panic)
+    #[test]
+    fn test_ctrl_n_p_empty_list() {
+        let nodes = mock_nodes();
+        let mut state = AppState::new(nodes);
+
+        state.handle_key(make_key(KeyCode::Char('n'), KeyModifiers::CONTROL), 0);
+        assert_eq!(state.selected_index, 0);
+        state.handle_key(make_key(KeyCode::Char('p'), KeyModifiers::CONTROL), 0);
+        assert_eq!(state.selected_index, 0);
+    }
+
+    /// Ctrl+N / Ctrl+P must not fall through to search input
+    #[test]
+    fn test_ctrl_n_does_not_type_into_search() {
+        let nodes = mock_nodes();
+        let mut state = AppState::new(nodes);
+
+        state.handle_key(make_key(KeyCode::Char('n'), KeyModifiers::CONTROL), 3);
+        state.handle_key(make_key(KeyCode::Char('p'), KeyModifiers::CONTROL), 3);
         assert!(state.search_query.is_empty());
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -437,13 +437,16 @@ fn render_status_bar(frame: &mut Frame, area: Rect, p: &Palette, narrow: bool) {
         ]
     } else {
         vec![
+            // Total width is 59 cols — must stay under the 60-col narrow cutoff.
             Span::styled("   Tab", Style::default().fg(p.accent)),
-            Span::styled(" Next Tab", Style::default().fg(p.overlay0)),
-            Span::styled("   S-Tab", Style::default().fg(p.accent)),
-            Span::styled(" Prev Tab", Style::default().fg(p.overlay0)),
-            Span::styled("   Enter", Style::default().fg(p.accent)),
+            Span::styled(" Next", Style::default().fg(p.overlay0)),
+            Span::styled("  S-Tab", Style::default().fg(p.accent)),
+            Span::styled(" Prev", Style::default().fg(p.overlay0)),
+            Span::styled("  ^p/^n", Style::default().fg(p.accent)),
+            Span::styled(" Move", Style::default().fg(p.overlay0)),
+            Span::styled("  Enter", Style::default().fg(p.accent)),
             Span::styled(" Focus", Style::default().fg(p.overlay0)),
-            Span::styled("   Esc", Style::default().fg(p.accent)),
+            Span::styled("  Esc", Style::default().fg(p.accent)),
             Span::styled(" Close", Style::default().fg(p.overlay0)),
         ]
     };


### PR DESCRIPTION
## Summary

Adds `Ctrl+P` / `Ctrl+N` as aliases for `↑` / `↓` in the navigator list, with
identical wrap-around behaviour. Arrow keys are unchanged — this is purely
additive.

Today those chords fall through to the catch-all `_ => KeyAction::Continue`
arm in `handle_key` and silently do nothing, so a user who reaches for them
gets no feedback and has to move to the arrow keys.

## Why Ctrl+P / Ctrl+N specifically

The navigator is a modal picker: it pops over the terminal, you type to filter,
you move a highlight, you hit Enter. That interaction already exists in Vim, and
it is bound to this exact pair:

| Vim context | Keys | Effect |
|---|---|---|
| Insert-mode completion popup (`:h i_CTRL-N`) | `Ctrl+N` / `Ctrl+P` | next / previous match in the popup menu |
| Command-line history (`:h c_CTRL-N`) | `Ctrl+N` / `Ctrl+P` | next / previous history entry |
| Wildmenu (`:h 'wildmenu'`) | `Ctrl+N` / `Ctrl+P` | next / previous completion candidate |

The common thread is *"a list is open, move within it without leaving the home
row"* — which is precisely this UI. Vim users don't reach for `j`/`k` here,
because in every one of the situations above the list appears while a text field
has focus, and `j`/`k` are literal characters being typed. This navigator has the
same constraint: the search query is always live, so `j`/`k` must stay as
searchable input. `Ctrl+P`/`Ctrl+N` are the motions Vim itself reaches for when
`j`/`k` are unavailable.

The same binding is the norm in the wider terminal-picker ecosystem — fzf,
telescope.nvim, and readline/Emacs `next-line`/`previous-line` all use it — so
the muscle memory arrives from several directions at once.

Deliberately **not** included: `Ctrl+J`/`Ctrl+K`. Happy to add them if you'd
prefer, but they're a second convention rather than the Vim-native one, and
`Ctrl+J` is `\n` on many terminals, which would collide with `Enter`.

## Changes

**`src/app.rs`** — the `Up` and `Down` match arms gain an alternate pattern:

```rust
(KeyCode::Up, _) | (KeyCode::Char('p'), KeyModifiers::CONTROL) => { ... }
(KeyCode::Down, _) | (KeyCode::Char('n'), KeyModifiers::CONTROL) => { ... }
```

The wrap-around bodies are extracted into `AppState::select_prev` /
`select_next` so the arrow and control-key paths share one implementation
rather than duplicating the `list_len == 0` guard that prevents the
`list_len - 1` underflow on an empty filtered list.

No input-layer change was needed: the event loop in `src/main.rs` already
forwards `modifiers` intact for `KeyEventKind::Press`, and `Ctrl+C` is matched
the same way. The character-input arm only matches `KeyModifiers::NONE |
KeyModifiers::SHIFT`, so a `CONTROL` arm cannot shadow it — `n` and `p` still
type into the search box normally.

**`src/ui.rs`** — the wide status bar gains a `^p/^n Move` hint. To make room,
`Next Tab`/`Prev Tab` are shortened to `Next`/`Prev` and the inter-hint gaps go
from 3 spaces to 2:

```
   Tab Next  S-Tab Prev  ^p/^n Move  Enter Focus  Esc Close
```

That is 59 columns. Wide mode begins at `area.width >= 60` (the `narrow`
threshold in `render`), so the line fits with 1 column to spare at the tightest
width that renders it — the naive version with the original spacing came to 63
and would have truncated `Close`. The narrow (`< 60`) branch is untouched.

**`README.md`** — the usage table row now reads
``| `↑` / `↓` or `Ctrl+P` / `Ctrl+N` | Navigate list |``.

## Tests

Four tests added to the existing `mod tests` in `src/app.rs`:

- `test_ctrl_n_moves_down_and_wraps` — 0 → 1 → 2 → 0 with `list_len = 3`
- `test_ctrl_p_moves_up_and_wraps` — 0 → 2 → 1 → 0 with `list_len = 3`
- `test_ctrl_n_p_empty_list` — `list_len = 0` stays at index 0, no underflow panic
- `test_ctrl_n_does_not_type_into_search` — guards the arm ordering, so a future
  edit can't regress these into search input

`cargo test` — 74 passed, 0 failed.
`cargo clippy --all-targets` — no new warnings (the 11 existing ones are
pre-existing and untouched; nearest to this diff is `useless_format` at
`src/ui.rs:221`).
`cargo build --release` — clean.
