### PR TITLE
settings: read theme and keybindings from the plugin config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,18 +157,30 @@ non-agent pane it jumps to the most recently focused agent.
 
 ## Configuration
 
+User settings live in `config.toml` inside the plugin's config directory, which
+Herdr keeps separate from the plugin files so upgrades never overwrite it:
+
+```bash
+herdr plugin config-dir beyondlex.herdr-recent-navigator
+# usually ~/.config/herdr/plugins/config/beyondlex.herdr-recent-navigator
+```
+
+Create `config.toml` there (the installer seeds a commented template if the
+file doesn't exist). Both `theme` and `[keybindings]` go in this one file:
+
+```toml
+theme = "light"
+
+[keybindings]
+move_up = ["Up", "C-k"]
+move_down = ["Down", "C-j"]
+```
+
+Settings still in `herdr-plugin.toml` (the old location) are honored as a
+fallback, but the installer regenerates that file on every upgrade, so move
+anything you've customized into `config.toml`.
+
 ### Theme
-
-The plugin reads its theme from the `theme` field in `herdr-plugin.toml`.
-Where to find that file depends on how you installed:
-
-| Install method | Manifest location |
-|---|---|
-| curl \| bash | `~/.local/share/herdr-recent-navigator/herdr-plugin.toml` |
-| `herdr plugin install`  | `~/.config/herdr/plugins/github/beyondlex.herdr-recent-navigator-*/herdr-plugin.toml` |
-| Build from source | `$PWD/herdr-plugin.toml` (repo root) |
-
-Add or edit the `theme` field:
 
 ```toml
 theme = "light"        # "dark" (default) or "light"
@@ -180,9 +192,8 @@ sends the theme name via `HERDR_PLUGIN_CONTEXT_JSON`.
 
 ### Keybindings
 
-All internal navigation keys are configurable via the `[keybindings]` section in
-`herdr-plugin.toml`. Each action accepts a list of key strings (multiple
-bindings per action).
+All internal navigation keys are configurable via the `[keybindings]` section.
+Each action accepts a list of key strings (multiple bindings per action).
 
 ```toml
 [keybindings]

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -4,7 +4,6 @@ version = "0.6.2"
 description = "Recent workspaces, tabs, panes, and AI agents switcher for Herdr."
 min_herdr_version = "0.7.4"
 platforms = ["macos", "linux"]
-theme = "dark"
 
 [[build]]
 command = ["cargo", "build", "--release"]
@@ -91,16 +90,6 @@ title = "Recent Navigator"
 placement = "popup"
 width = "60%"
 command = ["./target/release/herdr-recent-navigator"]
-
-[keybindings]
-next_category = ["Tab"]
-previous_category = ["S-Tab"]
-move_up = ["Up", "C-p"]
-move_down = ["Down", "C-n"]
-select = ["Enter"]
-dismiss = ["Esc"]
-force_quit = ["C-c"]
-backspace = ["Backspace"]
 
 # Optional: order and visibility of the navigator's category tabs. The array
 # carries both — position is display order, a tab left out is hidden.

--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,6 @@ version = "$VERSION"
 description = "Recent workspaces, tabs, panes, and AI agents switcher for Herdr."
 min_herdr_version = "0.7.4"
 platforms = ["macos", "linux"]
-theme = "dark"
 
 [[actions]]
 id = "open"
@@ -138,17 +137,6 @@ title = "Recent Navigator"
 placement = "popup"
 width = "60%"
 command = ["${INSTALL_DIR}/herdr-recent-navigator"]
-
-# Uncomment and edit to customize internal navigation keys:
-# [keybindings]
-# next_category = ["Tab"]
-# previous_category = ["S-Tab"]
-# move_up = ["Up", "C-p"]
-# move_down = ["Down", "C-n"]
-# select = ["Enter"]
-# dismiss = ["Esc"]
-# force_quit = ["C-c"]
-# backspace = ["Backspace"]
 PLUGIN_EOF
 
 # ── Symlink into PATH ────────────────────────────────
@@ -162,11 +150,41 @@ header "Linking Herdr plugin"
 if command -v herdr &>/dev/null; then
   info "Linking plugin into Herdr..."
   herdr plugin link "$INSTALL_DIR"
+
+  # Seed a settings template in Herdr's per-plugin config dir. This directory
+  # is never regenerated, so user edits survive upgrades. Never overwrite.
+  CONFIG_DIR="$(herdr plugin config-dir beyondlex.herdr-recent-navigator 2>/dev/null || true)"
+  if [ -n "$CONFIG_DIR" ]; then
+    CONFIG_FILE="$CONFIG_DIR/config.toml"
+    if [ ! -f "$CONFIG_FILE" ]; then
+      cat > "$CONFIG_FILE" <<'CONFIG_EOF'
+# Herdr Recent Navigator settings. This file is yours; upgrades never touch it.
+
+# "dark" (default) or "light"
+# theme = "dark"
+
+# Uncomment and edit to customize internal navigation keys:
+# [keybindings]
+# next_category = ["Tab"]
+# previous_category = ["S-Tab"]
+# move_up = ["Up", "C-p"]
+# move_down = ["Down", "C-n"]
+# select = ["Enter"]
+# dismiss = ["Esc"]
+# force_quit = ["C-c"]
+# backspace = ["Backspace"]
+CONFIG_EOF
+      ok "Created settings file at $CONFIG_FILE"
+    fi
+  else
+    CONFIG_FILE="\$(herdr plugin config-dir beyondlex.herdr-recent-navigator)/config.toml"
+  fi
+
   printf "\n  ${GREEN}${BOLD}✔ Installation complete!${NC}\n"
   printf "  ${DIM}Bind a shortcut to${NC} ${BOLD}recent-navigator.open${NC} ${DIM}in your Herdr config.${NC}\n"
-  printf "  ${DIM}Configure theme at${NC} ${BOLD}%s/herdr-plugin.toml${NC}${DIM}.${NC}\n\n" "$INSTALL_DIR"
+  printf "  ${DIM}Configure theme and keybindings at${NC} ${BOLD}%s${NC}${DIM}.${NC}\n\n" "$CONFIG_FILE"
 else
   warn "Herdr not found. Install Herdr first, then run:"
   printf "  ${CYAN}herdr plugin link${NC} ${DIM}%s${NC}\n" "$INSTALL_DIR"
-  printf "  ${DIM}Configure keybindings at${NC} ${BOLD}%s/herdr-plugin.toml${NC}${DIM}.${NC}\n\n" "$INSTALL_DIR"
+  printf "  ${DIM}Then configure theme and keybindings at${NC} ${BOLD}\$(herdr plugin config-dir beyondlex.herdr-recent-navigator)/config.toml${NC}${DIM}.${NC}\n\n"
 fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,7 +243,8 @@ fn run_inner(cli: &Cli) -> RunInnerResult {
         focused_pane_info.as_ref().map(|f| f.pane_id.clone()),
     );
 
-    let mut state = AppState::new(nodes, load_manifest_keybindings(), load_manifest_tabs());
+    let settings = PluginSettings::load();
+    let mut state = AppState::new(nodes, settings.keybindings(), load_manifest_tabs());
     state.theme_name = ctx.theme_name.clone();
 
     // Fallback 1: read the active theme from Herdr's own config, which is where
@@ -252,9 +253,9 @@ fn run_inner(cli: &Cli) -> RunInnerResult {
         state.theme_name = read_herdr_config_theme();
     }
 
-    // Fallback 2: read theme from plugin manifest when nothing else provides it
+    // Fallback 2: the plugin's own settings when nothing else provides one
     if state.theme_name.is_none() {
-        state.theme_name = read_manifest_theme();
+        state.theme_name = settings.theme();
     }
 
     if let Some(last) = AppState::load_last_category() {
@@ -907,40 +908,57 @@ fn read_herdr_config_theme() -> Option<String> {
     Some(name.to_string())
 }
 
-/// Read the `theme` field from the plugin's own manifest (`herdr-plugin.toml`).
-/// Used as a last resort when neither the context nor Herdr's config provides one.
-/// Returns `None` if the manifest is missing, unreadable, or has no theme field.
-fn read_manifest_theme() -> Option<String> {
-    let root = std::env::var("HERDR_PLUGIN_ROOT").ok()?;
-    let path = PathBuf::from(root).join("herdr-plugin.toml");
-    let content = std::fs::read_to_string(path).ok()?;
-    let value: toml::Value = content.parse().ok()?;
-    value.get("theme")?.as_str().map(String::from)
+/// User-editable plugin settings (`theme`, `[keybindings]`).
+///
+/// Resolved from two layers, first match wins per top-level key:
+/// 1. `$HERDR_PLUGIN_CONFIG_DIR/config.toml`: the stable per-plugin directory
+///    Herdr provides (`herdr plugin config-dir <id>`). Survives upgrades.
+/// 2. `$HERDR_PLUGIN_ROOT/herdr-plugin.toml`: the manifest. Kept as a fallback
+///    for existing installs, but installers regenerate it, so anything set
+///    there is lost on upgrade.
+struct PluginSettings {
+    user: Option<toml::Value>,
+    manifest: Option<toml::Value>,
 }
 
-/// Read the `[keybindings]` section from the plugin's manifest.
-/// Falls back to defaults if the section is missing or unreadable.
-fn load_manifest_keybindings() -> Keybindings {
-    let root = match std::env::var("HERDR_PLUGIN_ROOT").ok() {
-        Some(r) => r,
-        None => return Keybindings::default(),
-    };
-    let path = PathBuf::from(root).join("herdr-plugin.toml");
-    let content = match std::fs::read_to_string(path) {
-        Ok(c) => c,
-        Err(_) => return Keybindings::default(),
-    };
-    let value: toml::Value = match content.parse() {
-        Ok(v) => v,
-        Err(_) => return Keybindings::default(),
-    };
-    match value.get("keybindings") {
-        Some(kb) => {
-            let s = toml::to_string(&kb).unwrap_or_default();
-            toml::from_str(&s).unwrap_or_default()
-        }
-        None => Keybindings::default(),
+impl PluginSettings {
+    fn load() -> Self {
+        let user = std::env::var("HERDR_PLUGIN_CONFIG_DIR")
+            .ok()
+            .and_then(|d| read_toml(PathBuf::from(d).join("config.toml")));
+        let manifest = std::env::var("HERDR_PLUGIN_ROOT")
+            .ok()
+            .and_then(|r| read_toml(PathBuf::from(r).join("herdr-plugin.toml")));
+        PluginSettings { user, manifest }
     }
+
+    fn get(&self, key: &str) -> Option<&toml::Value> {
+        self.user
+            .as_ref()
+            .and_then(|v| v.get(key))
+            .or_else(|| self.manifest.as_ref().and_then(|v| v.get(key)))
+    }
+
+    /// `theme = "dark" | "light"`. Last-resort theme source when neither the
+    /// plugin context nor Herdr's own config names one.
+    fn theme(&self) -> Option<String> {
+        self.get("theme")?.as_str().map(String::from)
+    }
+
+    /// `[keybindings]` table; defaults when absent or malformed.
+    fn keybindings(&self) -> Keybindings {
+        match self.get("keybindings") {
+            Some(kb) => {
+                let s = toml::to_string(kb).unwrap_or_default();
+                toml::from_str(&s).unwrap_or_default()
+            }
+            None => Keybindings::default(),
+        }
+    }
+}
+
+fn read_toml(path: PathBuf) -> Option<toml::Value> {
+    std::fs::read_to_string(path).ok()?.parse().ok()
 }
 
 /// Read the configured category tabs from the manifest's `[navigator] tabs` —
@@ -1053,6 +1071,49 @@ mod theme_resolution_tests {
         with_herdr_config(Some("[theme]\nname = \"x-day\"\n"), || {
             let expected = std::env::var("HERDR_CONFIG_PATH").unwrap();
             assert_eq!(herdr_config_path(), Some(PathBuf::from(expected)));
+        });
+    }
+}
+
+#[cfg(test)]
+mod plugin_settings_tests {
+    use super::*;
+    use crate::test_helpers::with_plugin_dirs;
+
+    const MANIFEST: &str = "id = \"x\"\ntheme = \"dark\"\n\n[keybindings]\nmove_up = [\"Up\"]\n";
+
+    #[test]
+    fn user_config_overrides_manifest_per_key() {
+        // theme set in both -> user wins; keybindings only in manifest -> manifest used
+        with_plugin_dirs(Some("theme = \"light\"\n"), Some(MANIFEST), || {
+            let s = PluginSettings::load();
+            assert_eq!(s.theme(), Some("light".to_string()));
+            assert_eq!(s.keybindings().move_up, vec!["Up".to_string()]);
+        });
+    }
+
+    #[test]
+    fn falls_back_to_manifest_when_user_config_absent() {
+        with_plugin_dirs(None, Some(MANIFEST), || {
+            let s = PluginSettings::load();
+            assert_eq!(s.theme(), Some("dark".to_string()));
+            assert_eq!(s.keybindings().move_up, vec!["Up".to_string()]);
+        });
+    }
+
+    #[test]
+    fn defaults_when_neither_file_exists() {
+        with_plugin_dirs(None, None, || {
+            let s = PluginSettings::load();
+            assert_eq!(s.theme(), None);
+            assert_eq!(s.keybindings().move_up, Keybindings::default().move_up);
+        });
+    }
+
+    #[test]
+    fn malformed_user_config_does_not_mask_manifest() {
+        with_plugin_dirs(Some("theme = [broken"), Some(MANIFEST), || {
+            assert_eq!(PluginSettings::load().theme(), Some("dark".to_string()));
         });
     }
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -8,6 +8,7 @@ use tempfile::TempDir;
 
 static STATE_DIR_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 static CONFIG_PATH_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static PLUGIN_DIRS_LOCK: Mutex<()> = Mutex::new(());
 
 /// Create a temporary directory, set HERDR_PLUGIN_STATE_DIR to it,
 /// call the closure, then clean up.
@@ -61,6 +62,37 @@ pub fn with_herdr_config(contents: Option<&str>, f: impl FnOnce()) {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
     unsafe {
         std::env::remove_var("HERDR_CONFIG_PATH");
+    }
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
+}
+
+/// Point `HERDR_PLUGIN_CONFIG_DIR` and `HERDR_PLUGIN_ROOT` at temp dirs holding
+/// `config.toml` / `herdr-plugin.toml` with the given contents (`None` = absent),
+/// call the closure, then clean up.
+pub fn with_plugin_dirs(user_config: Option<&str>, manifest: Option<&str>, f: impl FnOnce()) {
+    let _guard = match PLUGIN_DIRS_LOCK.lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let config_dir = TempDir::new().expect("Failed to create temp dir");
+    let root_dir = TempDir::new().expect("Failed to create temp dir");
+    if let Some(c) = user_config {
+        std::fs::write(config_dir.path().join("config.toml"), c).expect("write config");
+    }
+    if let Some(m) = manifest {
+        std::fs::write(root_dir.path().join("herdr-plugin.toml"), m).expect("write manifest");
+    }
+    // SAFETY: We hold PLUGIN_DIRS_LOCK to prevent concurrent env var access.
+    unsafe {
+        std::env::set_var("HERDR_PLUGIN_CONFIG_DIR", config_dir.path());
+        std::env::set_var("HERDR_PLUGIN_ROOT", root_dir.path());
+    }
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    unsafe {
+        std::env::remove_var("HERDR_PLUGIN_CONFIG_DIR");
+        std::env::remove_var("HERDR_PLUGIN_ROOT");
     }
     if let Err(e) = result {
         std::panic::resume_unwind(e);


### PR DESCRIPTION
Fixes #6.

## Summary

- Add `PluginSettings`, loaded once at startup. Each top-level key is resolved from `$HERDR_PLUGIN_CONFIG_DIR/config.toml` first, then `$HERDR_PLUGIN_ROOT/herdr-plugin.toml`. The manifest fallback keeps existing installs working unchanged.
- `theme` and `[keybindings]` now come from `PluginSettings`; the two manifest-only readers are removed.
- `install.sh` no longer writes `theme` or a `[keybindings]` template into the manifest. After linking, it seeds a commented `config.toml` into the `herdr plugin config-dir` output if (and only if) the file does not exist, and points the user there.
- README: settings section now documents the config dir; manifest mentioned only as the legacy fallback.
- Repo `herdr-plugin.toml`: drop `theme` and `[keybindings]` so source builds match.

## Test plan

- [x] `cargo test`: 4 new tests in `plugin_settings_tests` (user config overrides manifest per key, manifest fallback, defaults when neither exists, malformed user config does not mask manifest).
- [x] Manual: manifest with no settings + `config.toml` with custom `[keybindings]` and the bindings apply. Re-ran `install.sh` twice: existing `config.toml` untouched (same checksum); with the file removed, the template is seeded.
- [ ] `integration_tests::test_run_inner_with_mock_data` fails on unmodified `main` on my machine (reads the real MRU state dir when `HERDR_PLUGIN_STATE_DIR` is unset); unrelated, left alone.