### PR TITLE
navigator: add categories setting to choose which tabs are shown

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,11 +1,27 @@
-use crate::models::{Action, AppState, KeyAction, Keybindings};
+use crate::models::{Action, AppState, CategoryTab, KeyAction, Keybindings};
 
 impl AppState {
     pub fn new(nodes: Vec<crate::models::NavigationNode>, keybindings: Keybindings) -> Self {
+        Self::with_categories(nodes, keybindings, CategoryTab::all().to_vec())
+    }
+
+    /// Build state showing only `categories` (display order). An empty list
+    /// falls back to all tabs so the UI always has something to cycle.
+    pub fn with_categories(
+        nodes: Vec<crate::models::NavigationNode>,
+        keybindings: Keybindings,
+        categories: Vec<CategoryTab>,
+    ) -> Self {
+        let categories = if categories.is_empty() {
+            CategoryTab::all().to_vec()
+        } else {
+            categories
+        };
         AppState {
             nodes,
             keybindings,
-            current_category: crate::models::CategoryTab::Workspaces,
+            current_category: categories[0].clone(),
+            categories,
             search_query: String::new(),
             selected_index: 0,
             spinner_tick: 0,
@@ -14,6 +30,15 @@ impl AppState {
             cached_displayed: std::rc::Rc::new(Vec::new()),
             cached_total: 0,
         }
+    }
+
+    /// Set the active tab, snapping to the first enabled tab if `cat` is hidden.
+    pub fn set_category(&mut self, cat: CategoryTab) {
+        self.current_category = if self.categories.contains(&cat) {
+            cat
+        } else {
+            self.categories[0].clone()
+        };
     }
 
     /// Process a crossterm key event. `list_len` is the length of the filtered
@@ -34,12 +59,12 @@ impl AppState {
             Some(Action::ForceQuit) => KeyAction::ExitDismiss,
             Some(Action::Select) => KeyAction::ExitSelect,
             Some(Action::NextCategory) => {
-                self.current_category = self.current_category.next();
+                self.current_category = self.current_category.next_in(&self.categories);
                 self.selected_index = 0;
                 KeyAction::Continue
             }
             Some(Action::PreviousCategory) => {
-                self.current_category = self.current_category.previous();
+                self.current_category = self.current_category.previous_in(&self.categories);
                 self.selected_index = 0;
                 KeyAction::Continue
             }
@@ -142,6 +167,28 @@ mod tests {
 
         state.handle_key(make_key(KeyCode::BackTab, KeyModifiers::SHIFT), 10);
         assert_eq!(state.current_category, CategoryTab::Panes);
+    }
+
+    /// With `categories` restricted, Tab/Shift+Tab skip hidden tabs and a
+    /// requested hidden tab snaps to the first enabled one.
+    #[test]
+    fn test_restricted_categories_skip_hidden_tabs() {
+        let mut state = AppState::with_categories(
+            mock_nodes(),
+            Keybindings::default(),
+            vec![CategoryTab::Workspaces, CategoryTab::Agents],
+        );
+        assert_eq!(state.current_category, CategoryTab::Workspaces);
+
+        state.handle_key(make_key(KeyCode::Tab, KeyModifiers::NONE), 10);
+        assert_eq!(state.current_category, CategoryTab::Agents);
+        state.handle_key(make_key(KeyCode::Tab, KeyModifiers::NONE), 10);
+        assert_eq!(state.current_category, CategoryTab::Workspaces);
+        state.handle_key(make_key(KeyCode::BackTab, KeyModifiers::SHIFT), 10);
+        assert_eq!(state.current_category, CategoryTab::Agents);
+
+        state.set_category(CategoryTab::Panes);
+        assert_eq!(state.current_category, CategoryTab::Workspaces);
     }
 
     /// Number keys should append to search query (not quick-select)

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,7 +241,11 @@ fn run_inner(cli: &Cli) -> RunInnerResult {
         focused_pane_info.as_ref().map(|f| f.pane_id.clone()),
     );
 
-    let mut state = AppState::new(nodes, load_manifest_keybindings());
+    let mut state = AppState::with_categories(
+        nodes,
+        load_manifest_keybindings(),
+        load_manifest_categories(),
+    );
     state.theme_name = ctx.theme_name.clone();
 
     // Fallback 1: read the active theme from Herdr's own config, which is where
@@ -256,12 +260,12 @@ fn run_inner(cli: &Cli) -> RunInnerResult {
     }
 
     if let Some(last) = AppState::load_last_category() {
-        state.current_category = last;
+        state.set_category(last);
     }
     if let Some(view) = &cli.view
         && let Ok(cat) = view.parse::<CategoryTab>()
     {
-        state.current_category = cat;
+        state.set_category(cat);
     }
 
     Ok((state, pane_ts, tab_ts, ws_ts, ctx, connected))
@@ -858,6 +862,34 @@ fn load_manifest_keybindings() -> Keybindings {
         }
         None => Keybindings::default(),
     }
+}
+
+/// Read `categories = ["workspaces", "agents"]` from the plugin's manifest.
+/// Returns the tabs to show, in manifest order. Unknown names are logged and
+/// skipped; a missing or empty list means all tabs.
+fn load_manifest_categories() -> Vec<CategoryTab> {
+    let Some(root) = std::env::var("HERDR_PLUGIN_ROOT").ok() else {
+        return Vec::new();
+    };
+    let path = PathBuf::from(root).join("herdr-plugin.toml");
+    let Some(value) = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|c| c.parse::<toml::Value>().ok())
+    else {
+        return Vec::new();
+    };
+    let Some(list) = value.get("categories").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    let mut out: Vec<CategoryTab> = Vec::with_capacity(list.len());
+    for item in list {
+        match item.as_str().map(str::parse::<CategoryTab>) {
+            Some(Ok(cat)) if !out.contains(&cat) => out.push(cat),
+            Some(Ok(_)) => {}
+            _ => log::warn!("manifest categories: ignoring invalid entry {item}"),
+        }
+    }
+    out
 }
 
 /// Extract pane_id from `herdr plugin pane open` JSON response.

--- a/src/models.rs
+++ b/src/models.rs
@@ -62,23 +62,21 @@ impl CategoryTab {
         ]
     }
 
-    /// Move to the next tab (wrapping).
-    pub fn next(&self) -> Self {
-        match self {
-            CategoryTab::Workspaces => CategoryTab::Tabs,
-            CategoryTab::Tabs => CategoryTab::Panes,
-            CategoryTab::Panes => CategoryTab::Agents,
-            CategoryTab::Agents => CategoryTab::Workspaces,
+    /// Move to the next tab within `enabled` (wrapping). If `self` is not
+    /// enabled, returns the first enabled tab.
+    pub fn next_in(&self, enabled: &[CategoryTab]) -> Self {
+        match enabled.iter().position(|t| t == self) {
+            Some(i) => enabled[(i + 1) % enabled.len()].clone(),
+            None => enabled[0].clone(),
         }
     }
 
-    /// Move to the previous tab (wrapping).
-    pub fn previous(&self) -> Self {
-        match self {
-            CategoryTab::Workspaces => CategoryTab::Agents,
-            CategoryTab::Tabs => CategoryTab::Workspaces,
-            CategoryTab::Panes => CategoryTab::Tabs,
-            CategoryTab::Agents => CategoryTab::Panes,
+    /// Move to the previous tab within `enabled` (wrapping). If `self` is not
+    /// enabled, returns the first enabled tab.
+    pub fn previous_in(&self, enabled: &[CategoryTab]) -> Self {
+        match enabled.iter().position(|t| t == self) {
+            Some(i) => enabled[(i + enabled.len() - 1) % enabled.len()].clone(),
+            None => enabled[0].clone(),
         }
     }
 
@@ -357,6 +355,8 @@ impl Keybindings {
 pub struct AppState {
     /// Configurable keybindings.
     pub keybindings: Keybindings,
+    /// Category tabs shown in the header, in display order. Never empty.
+    pub categories: Vec<CategoryTab>,
     /// Full list of navigation nodes.
     pub nodes: Vec<NavigationNode>,
     /// Currently selected category tab.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -212,7 +212,7 @@ pub fn render(frame: &mut Frame, state: &AppState, displayed: &[DisplayItem], to
 // ── Sub-renderers ───────────────────────────────────────────────────────────
 
 fn render_tabs(frame: &mut Frame, state: &AppState, area: Rect, p: &Palette, narrow: bool) {
-    let tabs = CategoryTab::all();
+    let tabs = &state.categories;
     let sel_idx = tabs
         .iter()
         .position(|t| t == &state.current_category)


### PR DESCRIPTION
Closes #7.

## Summary

- `AppState` gains `categories: Vec<CategoryTab>` (display order, never empty). `AppState::new` keeps all four; `AppState::with_categories` takes a list.
- `CategoryTab::next()/previous()` are replaced by `next_in(&[CategoryTab])` and `previous_in(...)` that cycle over the given list.
- `AppState::set_category` snaps a hidden tab to the first enabled one; the two places that set the tab at startup (`--view`, remembered last tab) go through it.
- `render_tabs` draws `state.categories` instead of `CategoryTab::all()`.
- `categories` is read from the manifest. Unknown names are logged and skipped; duplicates collapse; missing or empty means all tabs.

```toml
categories = ["workspaces", "agents"]
```

Independent of #8. If both merge, the reader becomes a one-line `PluginSettings::categories()`; happy to rebase whichever lands second.

## Test plan

- [x] `cargo test`: new `test_restricted_categories_skip_hidden_tabs` (Tab/Shift+Tab over `["workspaces","agents"]`, and `set_category(Panes)` snaps to Workspaces). Existing cycling tests unchanged and passing.
- [x] Manual: with the setting, header shows `Workspaces | Agents`, Tab lands on Agents, Tab again wraps to Workspaces. Key removed: all four tabs as before.