### PR TITLE
Workspaces tab: show linked git worktrees under their repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,9 @@ to customize.
 
 ### Category tabs
 
-- **Workspaces**: MRU workspaces with dot indicators for agent status
+- **Workspaces**: MRU workspaces with dot indicators for agent status.
+  Linked git worktrees show as `<repo> ⎇ <worktree>` directly under their
+  main-checkout workspace, and typing the repo name finds them
 - **Tabs**: MRU tabs within those workspaces
 - **Agents**: AI agents sorted by last activity
 - **Panes**: Individual terminal panes

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 
-use crate::models::{AgentStatus, NavigationNode, PaneOthers};
+use crate::models::{AgentStatus, NavigationNode, PaneOthers, WORKTREE_SEP};
 
 /// Information about the currently focused pane, captured during
 /// `fetch_all_nodes()` to avoid a redundant subprocess call.
@@ -36,6 +36,44 @@ struct WorkspaceListResult {
 struct WorkspaceInfo {
     workspace_id: String,
     label: String,
+    #[serde(default)]
+    worktree: Option<WorktreeInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorktreeInfo {
+    is_linked_worktree: bool,
+    repo_key: String,
+    repo_name: String,
+}
+
+/// Workspace label as shown in the navigator: a linked git worktree is
+/// prefixed with its main-checkout workspace label (or repo name when that
+/// workspace is absent) so it groups under, and searches with, its repo.
+fn workspace_labels(workspaces: &[WorkspaceInfo]) -> HashMap<String, String> {
+    let main_labels: HashMap<&str, &str> = workspaces
+        .iter()
+        .filter_map(|w| match &w.worktree {
+            Some(t) if !t.is_linked_worktree => Some((t.repo_key.as_str(), w.label.as_str())),
+            _ => None,
+        })
+        .collect();
+    workspaces
+        .iter()
+        .map(|w| {
+            let label = match &w.worktree {
+                Some(t) if t.is_linked_worktree => {
+                    let repo = main_labels
+                        .get(t.repo_key.as_str())
+                        .copied()
+                        .unwrap_or(&t.repo_name);
+                    format!("{repo}{WORKTREE_SEP}{}", w.label)
+                }
+                _ => w.label.clone(),
+            };
+            (w.workspace_id.clone(), label)
+        })
+        .collect()
 }
 
 #[derive(Debug, Deserialize)]
@@ -377,11 +415,7 @@ pub fn fetch_all_nodes() -> Result<(Vec<NavigationNode>, Option<FocusedPaneInfo>
         .unwrap_or_default();
 
     // ── Build local lookup maps ──
-    let ws_labels: HashMap<String, String> = ws_result
-        .workspaces
-        .iter()
-        .map(|w| (w.workspace_id.clone(), w.label.clone()))
-        .collect();
+    let ws_labels = workspace_labels(&ws_result.workspaces);
 
     let tab_names: HashMap<(String, String), String> = all_tabs
         .into_iter()

--- a/src/models.rs
+++ b/src/models.rs
@@ -25,6 +25,9 @@ impl AgentStatus {
     }
 }
 
+/// Separates a linked worktree's repo/main-workspace label from its own label.
+pub const WORKTREE_SEP: &str = " ⎇ ";
+
 /// A composite navigation node representing a pane with its workspace/tab/agent context.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NavigationNode {

--- a/src/mru.rs
+++ b/src/mru.rs
@@ -9,7 +9,9 @@ use nucleo_matcher::{Config, Matcher};
 // AgentStatus is only used in #[cfg(test)] code (make_node helper and test data).
 // The import is kept here so `use super::*` in tests can access it.
 #[allow(unused_imports)]
-use crate::models::{AgentStatus, CategoryTab, DisplayItem, NavigationNode, PaneOthers};
+use crate::models::{
+    AgentStatus, CategoryTab, DisplayItem, NavigationNode, PaneOthers, WORKTREE_SEP,
+};
 
 thread_local! {
     static FUZZY_MATCHER: RefCell<Matcher> = RefCell::new(Matcher::new(Config::DEFAULT));
@@ -182,7 +184,34 @@ fn build_workspace_items(
     }
     let mut items: Vec<DisplayItem> = map.into_values().collect();
     mru_sort(&mut items);
-    items
+    group_worktrees(items)
+}
+
+/// Move each linked-worktree workspace directly under its main-checkout
+/// workspace (matched by label prefix), keeping MRU order otherwise.
+fn group_worktrees(items: Vec<DisplayItem>) -> Vec<DisplayItem> {
+    let names: Vec<String> = items.iter().map(|it| it.sort_key()).collect();
+    let parent_of = |i: usize| {
+        names[i]
+            .split_once(WORKTREE_SEP)
+            .map(|(p, _)| p)
+            .filter(|p| names.iter().any(|n| n == p))
+    };
+    let mut out = Vec::with_capacity(items.len());
+    for (i, item) in items.iter().enumerate() {
+        if parent_of(i).is_some() {
+            continue;
+        }
+        out.push(item.clone());
+        out.extend(
+            items
+                .iter()
+                .enumerate()
+                .filter(|(j, _)| parent_of(*j) == Some(names[i].as_str()))
+                .map(|(_, child)| child.clone()),
+        );
+    }
+    out
 }
 
 fn build_tab_items(
@@ -882,6 +911,39 @@ mod tests {
         } else {
             panic!("Expected Workspace item");
         }
+    }
+
+    /// Linked worktrees sort directly under their main-checkout workspace.
+    #[test]
+    fn test_worktrees_group_under_main_workspace() {
+        let ws = |id: &str, name: &str, ts| make_node(id, id, name, "t", AgentStatus::None, ts, None);
+        let nodes = vec![
+            ws("ws-wt", "shed ⎇ feat", 30),
+            ws("ws-other", "notes", 20),
+            ws("ws-main", "shed", 10),
+            ws("ws-orphan", "lib ⎇ fix", 5),
+        ];
+        let ws_ts: HashMap<String, u64> = nodes
+            .iter()
+            .map(|n| (n.workspace_id.clone(), n.last_accessed_at))
+            .collect();
+        let empty = HashMap::new();
+        let empty_others = HashMap::new();
+        let opts = BuildOptions {
+            pane_ts: &empty,
+            tab_ts: &empty,
+            ws_ts: &ws_ts,
+            active_workspace_id: None,
+            active_pane_id: None,
+            active_tab_id: None,
+            self_pane_id: None,
+            others: &empty_others,
+        };
+        let names: Vec<String> = build_display_list(&nodes, &opts, &CategoryTab::Workspaces)
+            .iter()
+            .map(|it| it.sort_key())
+            .collect();
+        assert_eq!(names, ["notes", "shed", "shed ⎇ feat", "lib ⎇ fix"]);
     }
 
     /// Agents tab: only nodes with agent_id

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,7 @@
 use crate::format::*;
 use crate::models::{
     AgentStatus, AppState, CategoryTab, DisplayItem, Keybindings, OtherSource, OthersFilter,
+    WORKTREE_SEP,
 };
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Flex, Layout, Rect};
@@ -669,7 +670,17 @@ fn row_workspace(i: usize, name: &str, a: &[AgentStatus], ctx: &RowCtx) -> ListI
         .split(Rect::new(0, 0, rw, 1));
 
     let mut sp = vec![num_span(i, ctx.sel, ctx.p)];
-    sp.extend(col_spans(name, &cols[1], ctx.query, ns, hl));
+    match name.split_once(WORKTREE_SEP) {
+        Some((repo, wt)) => {
+            let total = cols[1].width as usize;
+            let repo_w = (UnicodeWidthStr::width(repo) + 1).min(total);
+            sp.extend(flex_col(repo, repo_w, ctx.query, ns, hl, false));
+            let wt = format!("{}{}", WORKTREE_SEP.trim_start(), wt);
+            let ws = ctx_style(ctx.sel, ctx.p);
+            sp.extend(flex_col(&wt, total - repo_w, ctx.query, ws, hl, false));
+        }
+        None => sp.extend(col_spans(name, &cols[1], ctx.query, ns, hl)),
+    }
     let dots_w = a.len() * 2;
     let dots_col_w = cols[2].width as usize;
     let pad = dots_col_w.saturating_sub(dots_w);


### PR DESCRIPTION
Closes #13

Parses the optional `worktree` object from `herdr workspace list`. A linked worktree renders as `<repo> ⎇ <worktree>` (suffix dimmed), sorts directly under its main-checkout workspace when that workspace is listed, and fuzzy search matches the full label so typing the repo name finds it. Workspaces without the field render exactly as before. No new dependencies.

## Tested

- `cargo test` (166 passing, incl. a new grouping test), `cargo clippy --all-targets` clean.
- Ran the release binary under a pty against a live herdr with `shed` (main checkout) and `test-worktree` (linked worktree); Workspaces tab shows:
  ```
   4. shed
   5. shed ⎇ test-worktree
  ```
  with the `⎇ test-worktree` part in the dim context colour. Typing `shed` filters to those two rows.
- `--mock --view workspaces` unchanged.